### PR TITLE
fix yarn/lerna setup

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,7 @@
   "packages": [
     "packages/*"
   ],
+  "npmClient": "yarn",
+  "useWorkspaces": true,
   "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "type": "git",
     "url": "git+ssh://git@github.com/9renpoto/javascript.git"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "allow-failsures": "run-p allow-failed:*",
     "build": "lerna run build",


### PR DESCRIPTION
To have the `yarn.lock` updated in the repo, you need to specify yarn + workspaces to lerna